### PR TITLE
Add new pattern for SAP community URL

### DIFF
--- a/.mlc.config.json
+++ b/.mlc.config.json
@@ -38,6 +38,9 @@
     },
     {
       "pattern": "https://help.sap.com/"
+    },
+    {
+      "pattern": "https://community.sap.com/"
     }
   ],
   "replacementPatterns": [


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Ignore the pattern: https://community.sap.com/ as the link check reports working links to community blog posts as broken

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
